### PR TITLE
[fix/ci-version-baseline] fix(ci): resolve build failure and reset package version baselines

### DIFF
--- a/.changeset/unified-baseline.md
+++ b/.changeset/unified-baseline.md
@@ -1,0 +1,34 @@
+---
+'@flexi-ui/avatar': major
+'@flexi-ui/button': major
+'@flexi-ui/form': major
+'@flexi-ui/input': major
+'@flexi-ui/link': major
+'@flexi-ui/ripple': major
+'@flexi-ui/spinner': major
+'@flexi-ui/styles': major
+'@flexi-ui/storage': major
+'@flexi-ui/system': major
+'@flexi-ui/system-rsc': major
+'@flexi-ui/theme': major
+'@flexi-ui/dom-animation': major
+'@flexi-ui/react-rsc-utils': major
+'@flexi-ui/react-utils': major
+'@flexi-ui/shared-icons': major
+'@flexi-ui/shared-utils': major
+'@flexi-ui/test-utils': major
+'@flexi-ui/use-aria-button': major
+'@flexi-ui/use-aria-link': major
+'@flexi-ui/use-callback-ref': major
+'@flexi-ui/use-css-variable': major
+'@flexi-ui/use-image': major
+'@flexi-ui/use-is-hydrated': major
+'@flexi-ui/use-list-data': major
+'@flexi-ui/use-measured-height': major
+'@flexi-ui/use-media-query': major
+'@flexi-ui/use-mounted': major
+'@flexi-ui/use-overlay-state': major
+'@flexi-ui/use-safe-layout-effect': major
+---
+
+Unified baseline release. Existing packages move to a single shared `6.0.0` line and brand-new packages (`@flexi-ui/avatar`, `@flexi-ui/styles`, plus the seven `use-*` hooks) start at `1.0.0`. No runtime behavior changes — this is a versioning re-alignment so every package in the monorepo ships from a consistent starting point going forward.

--- a/apps/documentation/next-sitemap.config.js
+++ b/apps/documentation/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
-export default {
-  siteUrl: "https://www.flexiui.com",
+module.exports = {
+  siteUrl: 'https://www.flexiui.com',
   generateRobotsTxt: true,
-  exclude: ["/examples/*"],
-};
+  exclude: ['/examples/*'],
+}

--- a/apps/documentation/next-sitemap.config.mjs
+++ b/apps/documentation/next-sitemap.config.mjs
@@ -1,6 +1,0 @@
-/** @type {import('next-sitemap').IConfig} */
-export default {
-  siteUrl: "https://www.flexiui.com",
-  generateRobotsTxt: true,
-  exclude: ["/examples/*"],
-};

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/avatar",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "The Avatar component is used to represent a user, and displays the profile picture, initials or fallback icon.",
   "type": "module",
   "license": "MIT",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/button",
-  "version": "5.0.1",
+  "version": "5.0.0",
   "description": "Buttons allow users to perform actions and choose with a single tap.",
   "type": "module",
   "license": "MIT",

--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/form",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "A form component that provides validation and submission handling.",
   "type": "module",
   "license": "MIT",

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/input",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "The input component is designed for capturing user input within a text field.",
   "type": "module",
   "license": "MIT",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/link",
-  "version": "4.0.1",
+  "version": "4.0.0",
   "description": "Links allow users to click their way from page to page. This component is styled to resemble a hyperlink and semantically renders an <a> element.",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-css-variable/package.json
+++ b/packages/hooks/use-css-variable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-css-variable",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook to read CSS custom property values with SSR support",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-image/package.json
+++ b/packages/hooks/use-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-image",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "React hook for progressing image loading",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-is-hydrated/package.json
+++ b/packages/hooks/use-is-hydrated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-is-hydrated",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook that returns true after client hydration",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-list-data/package.json
+++ b/packages/hooks/use-list-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-list-data",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook for managing immutable list data with selection and filtering",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-measured-height/package.json
+++ b/packages/hooks/use-measured-height/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-measured-height",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook to observe an element's scroll height via ResizeObserver",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-media-query/package.json
+++ b/packages/hooks/use-media-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-media-query",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook to subscribe to CSS media query changes",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-mounted/package.json
+++ b/packages/hooks/use-mounted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-mounted",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook that returns a getter for the mounted state",
   "type": "module",
   "license": "MIT",

--- a/packages/hooks/use-overlay-state/package.json
+++ b/packages/hooks/use-overlay-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/use-overlay-state",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "description": "React hook to manage controlled/uncontrolled overlay state",
   "type": "module",
   "license": "MIT",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/styles",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "FlexiUI core styles and Tailwind CSS component library",
   "author": {
     "name": "Muneeb Mughal",

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/system",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "description": "FlexiUI system primitives",
   "type": "module",
   "license": "MIT",

--- a/packages/utilities/react-utils/package.json
+++ b/packages/utilities/react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexi-ui/react-utils",
-  "version": "1.1.0",
+  "version": "1.0.4",
   "description": "A set of utilities for react on client side",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION


Fix next-sitemap.config.js ESM/CJS syntax error that broke CI builds. Reset all publishable package versions to match their current npm latest, and add a unified major changeset for the next release.